### PR TITLE
Addresses legibility and `latestVersion` in bump version error

### DIFF
--- a/src/components/steps/ReleaseFormStep.tsx
+++ b/src/components/steps/ReleaseFormStep.tsx
@@ -155,7 +155,10 @@ export default function ReleaseForm({
         version && latestVersion
           ? isValidBump(latestVersion, version)
             ? { isValid: true, message: `Valid bump from ${latestVersion}` }
-            : { isValid: false, message: "Next version is not a valid bump" }
+            : {
+                isValid: false,
+                message: `Next version is not a valid bump from ${latestVersion}`,
+              }
           : null,
       ],
     },
@@ -229,7 +232,7 @@ export default function ReleaseForm({
                 validation ? (
                   <div
                     key={i}
-                    className={`mt-2 text-xs ${
+                    className={`mt-2 font-poppins text-xs ${
                       validation.isValid
                         ? "text-success-green"
                         : "text-error-red"

--- a/src/components/steps/ReleasePublished.tsx
+++ b/src/components/steps/ReleasePublished.tsx
@@ -23,7 +23,9 @@ export default function IntroductionStep({
       {publishReqStatus.result && (
         <div>
           <span className="text-text-purple">Transaction hash: </span>
-          {publishReqStatus.result}
+          <span className="font-poppins font-medium">
+            {publishReqStatus.result}
+          </span>
         </div>
       )}
       <p>

--- a/src/components/steps/SignAndPublishStep.tsx
+++ b/src/components/steps/SignAndPublishStep.tsx
@@ -195,8 +195,10 @@ export default function SignAndPublish({
 
       {!isAllowedAddress ? (
         <div className="text-error-red">
-          The address {account}is not allowed to publish in this repo. Change to
-          an allowed account to continue
+          The address{" "}
+          <span className="font-poppins font-medium">{account + " "}</span>
+          is not allowed to publish in this repo. Change to an allowed account
+          to continue
         </div>
       ) : !isSigned ? (
         <>


### PR DESCRIPTION
- Applying Poppins font where addresses or data that includes numbers are shown due to legibility.
- Now the version bump validation error shows the latest version, so the user can know which has to be the next version according to a patch, a minor or a mayor