### PR TITLE
Developer address warning

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -175,6 +175,7 @@ export function App() {
             ipfsGatewayUrl={ipfsGatewayUrl}
             repoAddresses={repoAddresses}
             setRepoAddresses={setRepoAddresses}
+            account={account}
           />
         );
       case 4:

--- a/src/components/BaseCard.tsx
+++ b/src/components/BaseCard.tsx
@@ -4,14 +4,18 @@ import BackBtn from "./BackBtn";
 interface baseCardProps {
   hasBack?: () => void | undefined;
   children: React.ReactNode;
+  className?: string;
 }
 
 export default function BaseCard({
   hasBack = undefined,
   children,
+  className,
 }: baseCardProps) {
   return (
-    <div className="relative mt-[6%] flex min-h-min w-4/5 flex-col md:w-4/5 lg:w-3/5 2xl:w-2/5">
+    <div
+      className={`relative mt-[6%] flex min-h-min w-4/5 flex-col md:w-4/5 lg:w-3/5 2xl:w-2/5 ${className}`}
+    >
       {hasBack && <BackBtn onClick={() => hasBack()} />}
       <div className="flex flex-col gap-5 rounded-3xl bg-white p-9">
         {children}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -4,16 +4,18 @@ interface buttonProps {
   children: React.ReactNode;
   onClick: () => void;
   disabled?: boolean;
+  className?: string;
 }
 
 export default function Button({
   children,
   onClick,
   disabled = false,
+  className,
 }: buttonProps) {
   return (
     <button
-      className="flex w-full min-w-max items-center justify-center rounded-2xl bg-default-purple px-3 pb-2.5 pt-3 text-text-purple transition-all duration-300 ease-in-out hover:bg-focused-purple hover:tracking-widest hover:text-white disabled:bg-background-color disabled:tracking-normal disabled:text-gray-400"
+      className={`flex w-full min-w-max items-center justify-center rounded-2xl bg-default-purple px-3 pb-2.5 pt-3 text-text-purple transition-all duration-300 ease-in-out hover:bg-focused-purple hover:tracking-widest hover:text-white disabled:bg-background-color disabled:tracking-normal disabled:text-gray-400 ${className}`}
       onClick={() => onClick()}
       disabled={disabled}
     >

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -6,6 +6,7 @@ interface inputProps {
   value: string;
   success?: boolean;
   error?: boolean;
+  warning?: boolean;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
@@ -16,6 +17,7 @@ export default function Input({
   onChange,
   error,
   success,
+  warning,
 }: inputProps) {
   return (
     <div className="flex flex-col">
@@ -23,10 +25,14 @@ export default function Input({
       <input
         type="text"
         className={`w-full min-w-max rounded-2xl bg-background-color px-2 py-2 text-sm focus:outline-focused-purple ${
+          (error || warning || success) && "outline outline-1"
+        } ${
           error
             ? "text-error-red outline outline-1 outline-error-red focus:outline-error-red"
-            : success &&
-              "outline outline-1 outline-green-500 focus:outline-green-500"
+            : warning
+              ? "text-yellow-600 outline outline-1 outline-yellow-600 focus:outline-yellow-600 "
+              : success &&
+                "outline outline-1 outline-green-500 focus:outline-green-500"
         }`}
         placeholder={placeholder}
         value={value}

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -28,11 +28,10 @@ export default function Input({
           (error || warning || success) && "outline outline-1"
         } ${
           error
-            ? "text-error-red outline outline-1 outline-error-red focus:outline-error-red"
+            ? "outline-error-red focus:outline-error-red"
             : warning
-              ? "text-yellow-600 outline outline-1 outline-yellow-600 focus:outline-yellow-600 "
-              : success &&
-                "outline outline-1 outline-green-500 focus:outline-green-500"
+              ? "outline-yellow-600 focus:outline-yellow-600 "
+              : success && "outline-green-500 focus:outline-green-500"
         }`}
         placeholder={placeholder}
         value={value}

--- a/src/components/steps/ReleaseFormStep.tsx
+++ b/src/components/steps/ReleaseFormStep.tsx
@@ -144,6 +144,19 @@ export default function ReleaseForm({
             : { isValid: false, message: "Must be a valid ethereum address" }
           : null,
       ],
+      warnings: [
+        developerAddress
+          ? developerAddress.toLowerCase() === account?.toLowerCase()
+            ? {
+                isValid: true,
+                message: "Developer address is the same the one publishing",
+              }
+            : {
+                isValid: false,
+                message: "Developer address diferent from the one publishing",
+              }
+          : null,
+      ],
     },
     {
       name: "Next version",
@@ -205,7 +218,10 @@ export default function ReleaseForm({
     .map((validation) => validation?.message ?? "");
 
   const handleNext = () => {
-    if (!developerAddress || developerAddress === account) {
+    if (
+      !developerAddress ||
+      developerAddress.toLowerCase() === account?.toLowerCase()
+    ) {
       setStepper((prevState) => prevState + 1);
     } else {
       setShowDevAddressModal(true);
@@ -217,20 +233,19 @@ export default function ReleaseForm({
       <div className="absolute left-0 top-0 z-10 flex h-screen w-screen items-center justify-center bg-black/80">
         <BaseCard className="m-0">
           <Title title={"Developer Address Warning"} />
-          <b className="font-poppins"> Read this before going forward: </b>
+          <p className="font-poppins">
+            Setting a developer address will restrict future releases when
+            publishing. Read this before going forward:
+          </p>
           <ul className="flex list-disc flex-col gap-5 pl-5 font-poppins marker:text-text-purple">
-            <li>
-              Setting a developer address will restrict future releases of this
-              package to the developer address you set, preventing the use of
-              your current Ethereum address for publishing.
-            </li>
             <li>
               Only the specified developer address will be able to publish new
               versions of this package.
             </li>
             <li>
-              If you lose access to the developer address, the package could
-              become "orphaned," making it impossible to publish new versions.
+              If you lose access to the developer address,{" "}
+              <b>the package could become "orphaned" </b> , making it impossible
+              to publish new versions.
             </li>
           </ul>
           <div className="flex flex-row gap-3">
@@ -277,6 +292,7 @@ export default function ReleaseForm({
         </p>
         {fields.map((field, i) => {
           const validations = (field.validations || []).filter(notNullish);
+          const warnings = (field.warnings || []).filter(notNullish);
           const success = validations.filter((v) => v && v.isValid);
           const errors = validations.filter((v) => v && !v.isValid);
           return (
@@ -288,24 +304,40 @@ export default function ReleaseForm({
                 value={field.value}
                 error={errors.length > 0}
                 success={success.length > 0}
+                warning={warnings.length > 0}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                   field.onValueChange(e.target.value)
                 }
               ></Input>
               {field.validations &&
-                field.validations.map((validation, i) =>
-                  validation ? (
-                    <div
-                      key={i}
-                      className={`mt-2 font-poppins text-xs ${
-                        validation.isValid
-                          ? "text-success-green"
-                          : "text-error-red"
-                      }`}
-                    >
-                      {validation.message}
-                    </div>
-                  ) : null,
+                field.validations.map(
+                  (validation, i) =>
+                    validation && (
+                      <div
+                        key={i}
+                        className={`mt-2 font-poppins text-xs ${
+                          validation.isValid
+                            ? "text-success-green"
+                            : "text-error-red"
+                        }`}
+                      >
+                        {validation.message}
+                      </div>
+                    ),
+                )}
+              {field.warnings &&
+                field.warnings.map(
+                  (warning, i) =>
+                    warning && (
+                      <div
+                        key={i}
+                        className={`mt-2 text-xs ${
+                          warning.isValid ? "text-error-red" : "text-yellow-600"
+                        }`}
+                      >
+                        {warning.message}
+                      </div>
+                    ),
                 )}
             </div>
           );

--- a/src/components/steps/ReleaseFormStep.tsx
+++ b/src/components/steps/ReleaseFormStep.tsx
@@ -149,11 +149,12 @@ export default function ReleaseForm({
           ? developerAddress.toLowerCase() === account?.toLowerCase()
             ? {
                 isValid: true,
-                message: "Developer address is the same the one publishing",
+                message: "Developer address is the same as the one publishing",
               }
             : {
                 isValid: false,
-                message: "Developer address different from the one publishing",
+                message:
+                  "Developer address is different from the one publishing",
               }
           : null,
       ],

--- a/src/components/steps/ReleaseFormStep.tsx
+++ b/src/components/steps/ReleaseFormStep.tsx
@@ -295,6 +295,7 @@ export default function ReleaseForm({
           const warnings = (field.warnings || []).filter(notNullish);
           const success = validations.filter((v) => v && v.isValid);
           const errors = validations.filter((v) => v && !v.isValid);
+          const filteredWarnings = warnings.filter((w) => w && !w.isValid);
           return (
             <div key={i}>
               <Input
@@ -304,7 +305,7 @@ export default function ReleaseForm({
                 value={field.value}
                 error={errors.length > 0}
                 success={success.length > 0}
-                warning={warnings.length > 0}
+                warning={filteredWarnings.length > 0}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                   field.onValueChange(e.target.value)
                 }
@@ -332,7 +333,9 @@ export default function ReleaseForm({
                       <div
                         key={i}
                         className={`mt-2 text-xs ${
-                          warning.isValid ? "text-error-red" : "text-yellow-600"
+                          warning.isValid
+                            ? "text-success-green"
+                            : "text-yellow-600"
                         }`}
                       >
                         {warning.message}

--- a/src/components/steps/ReleaseFormStep.tsx
+++ b/src/components/steps/ReleaseFormStep.tsx
@@ -153,7 +153,7 @@ export default function ReleaseForm({
               }
             : {
                 isValid: false,
-                message: "Developer address diferent from the one publishing",
+                message: "Developer address different from the one publishing",
               }
           : null,
       ],
@@ -232,7 +232,7 @@ export default function ReleaseForm({
     return (
       <div className="absolute left-0 top-0 z-10 flex h-screen w-screen items-center justify-center bg-black/80">
         <BaseCard className="m-0">
-          <Title title={"Developer Address Warning"} />
+          <Title title={"⚠️ Developer Address Warning ⚠️"} />
           <p className="font-poppins">
             Setting a developer address will restrict future releases when
             publishing. Read this before going forward:

--- a/src/components/steps/ReleaseFormStep.tsx
+++ b/src/components/steps/ReleaseFormStep.tsx
@@ -30,6 +30,7 @@ interface ReleaseFormProps {
   setRepoAddresses: React.Dispatch<
     React.SetStateAction<RepoAddresses | undefined>
   >;
+  account: string | null;
 }
 
 export default function ReleaseForm({
@@ -46,12 +47,15 @@ export default function ReleaseForm({
   ipfsGatewayUrl,
   repoAddresses,
   setRepoAddresses,
+  account,
 }: ReleaseFormProps) {
   const [latestVersion, setLatestVersion] = useState<string>();
   const [manifest, setManifest] = useState<
     (Manifest & { hash: string }) | null
   >();
-  console.log(dnpName);
+
+  const [showDevAddressModal, setShowDevAddressModal] = useState(false);
+  const [devAddressCheck, setDevAddressCheck] = useState(false);
 
   useEffect(() => {
     async function checkManifest(hash: string) {
@@ -200,63 +204,125 @@ export default function ReleaseForm({
     .filter((validation) => validation !== null && !validation?.isValid)
     .map((validation) => validation?.message ?? "");
 
-  return (
-    <BaseCard
-      hasBack={() => {
-        setStepper((prevState) => prevState - 1);
-      }}
-    >
-      <Title title={"3. Release Details"} />
-      <p>
-        Fulfill the following form with the information of your package release.
-      </p>
-      {fields.map((field, i) => {
-        const validations = (field.validations || []).filter(notNullish);
-        const success = validations.filter((v) => v && v.isValid);
-        const errors = validations.filter((v) => v && !v.isValid);
-        return (
-          <div key={i}>
-            <Input
-              key={field.name}
-              name={field.name}
-              placeholder={field.placeholder}
-              value={field.value}
-              error={errors.length > 0}
-              success={success.length > 0}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                field.onValueChange(e.target.value)
-              }
-            ></Input>
-            {field.validations &&
-              field.validations.map((validation, i) =>
-                validation ? (
-                  <div
-                    key={i}
-                    className={`mt-2 font-poppins text-xs ${
-                      validation.isValid
-                        ? "text-success-green"
-                        : "text-error-red"
-                    }`}
-                  >
-                    {validation.message}
-                  </div>
-                ) : null,
-              )}
+  const handleNext = () => {
+    if (!developerAddress || developerAddress === account) {
+      setStepper((prevState) => prevState + 1);
+    } else {
+      setShowDevAddressModal(true);
+    }
+  };
+
+  function DevAddressWarningModal() {
+    return (
+      <div className="absolute left-0 top-0 z-10 flex h-screen w-screen items-center justify-center bg-black/80">
+        <BaseCard className="m-0">
+          <Title title={"Developer Address Warning"} />
+          <b className="font-poppins"> Read this before going forward: </b>
+          <ul className="flex list-disc flex-col gap-5 pl-5 font-poppins marker:text-text-purple">
+            <li>
+              Setting a developer address will restrict future releases of this
+              package to the developer address you set, preventing the use of
+              your current Ethereum address for publishing.
+            </li>
+            <li>
+              Only the specified developer address will be able to publish new
+              versions of this package.
+            </li>
+            <li>
+              If you lose access to the developer address, the package could
+              become "orphaned," making it impossible to publish new versions.
+            </li>
+          </ul>
+          <div className="flex flex-row gap-3">
+            <input
+              type="checkbox"
+              className="h-5 w-5 accent-text-purple"
+              onChange={() => setDevAddressCheck(!devAddressCheck)}
+              checked={devAddressCheck}
+            />{" "}
+            <p>I undestrand the risks of setting a developer address</p>
           </div>
-        );
-      })}
-      <Button
-        onClick={() => setStepper((prevState) => prevState + 1)}
-        disabled={
-          errors.length > 0 ||
-          !dnpName ||
-          !version ||
-          !releaseHash ||
-          !repoAddresses
-        }
+
+          <div className="flex flex-row gap-10">
+            <div className="w-1/2">
+              <Button onClick={() => setShowDevAddressModal(false)}>
+                Go back
+              </Button>
+            </div>
+            <div className="w-1/2 ">
+              <Button
+                disabled={!devAddressCheck}
+                onClick={() => setStepper((prevState) => prevState + 1)}
+              >
+                Continue anyway
+              </Button>
+            </div>
+          </div>
+        </BaseCard>
+      </div>
+    );
+  }
+  return (
+    <>
+      {showDevAddressModal && DevAddressWarningModal()}
+      <BaseCard
+        hasBack={() => {
+          setStepper((prevState) => prevState - 1);
+        }}
       >
-        Next
-      </Button>
-    </BaseCard>
+        <Title title={"3. Release Details"} />
+        <p>
+          Fulfill the following form with the information of your package
+          release.
+        </p>
+        {fields.map((field, i) => {
+          const validations = (field.validations || []).filter(notNullish);
+          const success = validations.filter((v) => v && v.isValid);
+          const errors = validations.filter((v) => v && !v.isValid);
+          return (
+            <div key={i}>
+              <Input
+                key={field.name}
+                name={field.name}
+                placeholder={field.placeholder}
+                value={field.value}
+                error={errors.length > 0}
+                success={success.length > 0}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  field.onValueChange(e.target.value)
+                }
+              ></Input>
+              {field.validations &&
+                field.validations.map((validation, i) =>
+                  validation ? (
+                    <div
+                      key={i}
+                      className={`mt-2 font-poppins text-xs ${
+                        validation.isValid
+                          ? "text-success-green"
+                          : "text-error-red"
+                      }`}
+                    >
+                      {validation.message}
+                    </div>
+                  ) : null,
+                )}
+            </div>
+          );
+        })}
+        <Button
+          onClick={handleNext}
+          disabled={
+            errors.length > 0 ||
+            !dnpName ||
+            !version ||
+            !releaseHash ||
+            !repoAddresses
+          }
+        >
+          Next
+        </Button>
+      </BaseCard>
+    </>
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export interface FormField {
   value: any;
   onValueChange: (newValue: any) => void;
   validations?: FormFieldValidation[];
+  warnings?: FormFieldValidation[];
 }
 export interface ReleaseDetails {
   name: string;


### PR DESCRIPTION
Now, if user inputs a developer address, and it's different from the ethereum provider address, a confirmation modal appears between the `ReleaseForm` and the `Sign&Publish`steps. Also implementing warning validations for the inputs.