### PR TITLE
No wallet detected copy

### DIFF
--- a/src/components/steps/ConnectWalletStep.tsx
+++ b/src/components/steps/ConnectWalletStep.tsx
@@ -126,7 +126,8 @@ export default function ConnectWalletStep({
         )
       ) : (
         <p>
-          Non-Ethereum browser detected. Please, install MetaMask to continue
+          No Ethereum wallet extension detected on browser. Please, install
+          MetaMask to continue.
         </p>
       )}
     </BaseCard>


### PR DESCRIPTION
Updating copy to "No Ethereum wallet extension detected in the browser" when no wallet is detected.