### PR TITLE
Overwrite legacy IPFS gateway

### DIFF
--- a/src/params.ts
+++ b/src/params.ts
@@ -3,6 +3,7 @@
 //export const DEFAULT_IPFS_GATEWAY = "https://cloudflare-ipfs.com";
 export const DEFAULT_IPFS_GATEWAY = "https://ipfs-gateway-dev.dappnode.net";
 export const DEFAULT_IPFS_API = "https://api.ipfs.dappnode.io/";
+export const LEGACY_IPFS_GATEWAY = "https://gateway-dev.ipfs.dappnode.io";
 
 export const SDK_GUIDE_LINK =
   "https://github.com/dappnode/DAppNodeSDK/wiki/DAppNode-SDK-tutorial";

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_IPFS_GATEWAY, LEGACY_IPFS_GATEWAY } from "params";
+
 const ipfsApiUrlsKey = "ipfs-api-urls";
 
 export function readIpfsApiUrls(): string {
@@ -11,7 +13,13 @@ export function writeIpfsApiUrls(ipfsApiUrls: string): void {
 const ipfsGatewayUrlKey = "ipfs-gateway-urls";
 
 export function readIpfsGatewayUrl(): string {
-  return localStorage.getItem(ipfsGatewayUrlKey) ?? "";
+  const storedGateway = localStorage.getItem(ipfsGatewayUrlKey) ?? "";
+  // Overwrite legacy gateway with the new default
+  if (storedGateway === LEGACY_IPFS_GATEWAY) {
+    writeIpfsGatewayUrl(DEFAULT_IPFS_GATEWAY);
+    return DEFAULT_IPFS_GATEWAY;
+  }
+  return storedGateway;
 }
 
 export function writeIpfsGatewayUrl(ipfsGatewayUrl: string): void {


### PR DESCRIPTION
If the IPFS gateway stored in localStorage matches `LEGACY_IPFS_GATEWAY`, it is replaced with the new gateway