### PR TITLE
feat: integrate IPFS propagation API after release signing

### DIFF
--- a/src/pages/publishing/Publishing.tsx
+++ b/src/pages/publishing/Publishing.tsx
@@ -1,6 +1,6 @@
 import { DEFAULT_IPFS_API, DEFAULT_IPFS_GATEWAY } from "params";
 import React, { useEffect, useState } from "react";
-import { readIpfsApiUrls, readIpfsGatewayUrl } from "settings";
+import { readIpfsApiUrls, readIpfsGatewayUrl, readPropagationUrl } from "settings";
 import { RepoAddresses, RequestStatus } from "types";
 import { parseUrlQuery } from "utils/urlQuery";
 import IntroductionStep from "pages/publishing/steps/IntroductionStep";
@@ -30,6 +30,7 @@ export function Publishing() {
   const [ipfsGatewayUrl, setIpfsGatewayUrl] = useState(
     readIpfsGatewayUrl() === "" ? DEFAULT_IPFS_GATEWAY : readIpfsGatewayUrl(),
   );
+  const [propagationUrl, setPropagationUrl] = useState(readPropagationUrl());
 
   // Set state based on URL parameters
   useEffect(() => {
@@ -65,6 +66,8 @@ export function Publishing() {
             setIpfsApiUrls={setIpfsApiUrls}
             ipfsGatewayUrl={ipfsGatewayUrl}
             setIpfsGatewayUrl={setIpfsGatewayUrl}
+            propagationUrl={propagationUrl}
+            setPropagationUrl={setPropagationUrl}
           />
         );
       case 2:
@@ -97,6 +100,7 @@ export function Publishing() {
             setPublishReqStatus={setPublishReqStatus}
             ipfsApiUrls={ipfsApiUrls}
             ipfsGatewayUrl={ipfsGatewayUrl}
+            propagationUrl={propagationUrl}
           />
         );
       case 4:

--- a/src/pages/publishing/Publishing.tsx
+++ b/src/pages/publishing/Publishing.tsx
@@ -1,6 +1,6 @@
 import { DEFAULT_IPFS_API, DEFAULT_IPFS_GATEWAY } from "params";
 import React, { useEffect, useState } from "react";
-import { readIpfsApiUrls, readIpfsGatewayUrl, readPropagationUrl } from "settings";
+import { readIpfsApiUrls, readIpfsGatewayUrl, readPropagationApiKey, readPropagationUrl } from "settings";
 import { RepoAddresses, RequestStatus } from "types";
 import { parseUrlQuery } from "utils/urlQuery";
 import IntroductionStep from "pages/publishing/steps/IntroductionStep";
@@ -31,6 +31,9 @@ export function Publishing() {
     readIpfsGatewayUrl() === "" ? DEFAULT_IPFS_GATEWAY : readIpfsGatewayUrl(),
   );
   const [propagationUrl, setPropagationUrl] = useState(readPropagationUrl());
+  const [propagationApiKey, setPropagationApiKey] = useState(
+    readPropagationApiKey(),
+  );
 
   // Set state based on URL parameters
   useEffect(() => {
@@ -68,6 +71,8 @@ export function Publishing() {
             setIpfsGatewayUrl={setIpfsGatewayUrl}
             propagationUrl={propagationUrl}
             setPropagationUrl={setPropagationUrl}
+            propagationApiKey={propagationApiKey}
+            setPropagationApiKey={setPropagationApiKey}
           />
         );
       case 2:
@@ -101,6 +106,7 @@ export function Publishing() {
             ipfsApiUrls={ipfsApiUrls}
             ipfsGatewayUrl={ipfsGatewayUrl}
             propagationUrl={propagationUrl}
+            propagationApiKey={propagationApiKey}
           />
         );
       case 4:

--- a/src/pages/publishing/steps/IpfsSettingsStep.tsx
+++ b/src/pages/publishing/steps/IpfsSettingsStep.tsx
@@ -1,5 +1,10 @@
 import React, { useEffect } from "react";
-import { writeIpfsApiUrls, writeIpfsGatewayUrl, writePropagationUrl } from "settings";
+import {
+  writeIpfsApiUrls,
+  writeIpfsGatewayUrl,
+  writePropagationApiKey,
+  writePropagationUrl,
+} from "settings";
 import BaseCard from "components/BaseCard";
 import Button from "components/Button";
 import Title from "components/Title";
@@ -12,6 +17,8 @@ interface IpfsSettingsStepProps {
   setIpfsGatewayUrl: React.Dispatch<React.SetStateAction<string>>;
   propagationUrl: string;
   setPropagationUrl: React.Dispatch<React.SetStateAction<string>>;
+  propagationApiKey: string;
+  setPropagationApiKey: React.Dispatch<React.SetStateAction<string>>;
 }
 
 export default function IpfsSettingsStep({
@@ -22,10 +29,13 @@ export default function IpfsSettingsStep({
   setIpfsGatewayUrl,
   propagationUrl,
   setPropagationUrl,
+  propagationApiKey,
+  setPropagationApiKey,
 }: IpfsSettingsStepProps) {
   useEffect(() => writeIpfsApiUrls(ipfsApiUrls), [ipfsApiUrls]);
   useEffect(() => writeIpfsGatewayUrl(ipfsGatewayUrl), [ipfsGatewayUrl]);
   useEffect(() => writePropagationUrl(propagationUrl), [propagationUrl]);
+  useEffect(() => writePropagationApiKey(propagationApiKey), [propagationApiKey]);
   return (
     <BaseCard hasBack={() => setStepper((prevState) => prevState - 1)}>
       <Title title={"2. Edit IPFS settings"} />
@@ -77,6 +87,18 @@ export default function IpfsSettingsStep({
           placeholder="https://propagation-api.dappnode.io"
           value={propagationUrl}
           onChange={(e) => setPropagationUrl(e.target.value)}
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <div className="text-text-purple text-xs">API Key</div>
+        <input
+          className={
+            " rounded-2xl bg-background-color p-3 text-xs focus:outline-focused-purple "
+          }
+          type="password"
+          placeholder="Optional — skips signature prompt"
+          value={propagationApiKey}
+          onChange={(e) => setPropagationApiKey(e.target.value)}
         />
       </div>
       <Button onClick={() => setStepper((prevState) => prevState + 1)}>

--- a/src/pages/publishing/steps/IpfsSettingsStep.tsx
+++ b/src/pages/publishing/steps/IpfsSettingsStep.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { writeIpfsApiUrls, writeIpfsGatewayUrl } from "settings";
+import { writeIpfsApiUrls, writeIpfsGatewayUrl, writePropagationUrl } from "settings";
 import BaseCard from "components/BaseCard";
 import Button from "components/Button";
 import Title from "components/Title";
@@ -10,6 +10,8 @@ interface IpfsSettingsStepProps {
   setIpfsApiUrls: React.Dispatch<React.SetStateAction<string>>;
   ipfsGatewayUrl: string;
   setIpfsGatewayUrl: React.Dispatch<React.SetStateAction<string>>;
+  propagationUrl: string;
+  setPropagationUrl: React.Dispatch<React.SetStateAction<string>>;
 }
 
 export default function IpfsSettingsStep({
@@ -18,9 +20,12 @@ export default function IpfsSettingsStep({
   setIpfsApiUrls,
   ipfsGatewayUrl,
   setIpfsGatewayUrl,
+  propagationUrl,
+  setPropagationUrl,
 }: IpfsSettingsStepProps) {
   useEffect(() => writeIpfsApiUrls(ipfsApiUrls), [ipfsApiUrls]);
   useEffect(() => writeIpfsGatewayUrl(ipfsGatewayUrl), [ipfsGatewayUrl]);
+  useEffect(() => writePropagationUrl(propagationUrl), [propagationUrl]);
   return (
     <BaseCard hasBack={() => setStepper((prevState) => prevState - 1)}>
       <Title title={"2. Edit IPFS settings"} />
@@ -58,6 +63,20 @@ export default function IpfsSettingsStep({
           placeholder="https://some-ipfs-gateway"
           value={ipfsGatewayUrl}
           onChange={(e) => setIpfsGatewayUrl(e.target.value)}
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <div className="text-text-purple">Propagation API URL</div>
+        <p className="text-sm">
+          URL of the DAppNode propagation service. Leave empty to disable.
+        </p>
+        <input
+          className={
+            " rounded-2xl bg-background-color p-3  focus:outline-focused-purple "
+          }
+          placeholder="https://propagation-api.dappnode.io"
+          value={propagationUrl}
+          onChange={(e) => setPropagationUrl(e.target.value)}
         />
       </div>
       <Button onClick={() => setStepper((prevState) => prevState + 1)}>

--- a/src/pages/publishing/steps/SignAndPublishStep.tsx
+++ b/src/pages/publishing/steps/SignAndPublishStep.tsx
@@ -10,6 +10,10 @@ import { parseIpfsUrls } from "settings";
 import { apmRepoIsAllowed } from "utils/apmRepoIsAllowed";
 import { executePublishTx } from "utils/executePublishTx";
 import { fetchReleaseSignature } from "utils/fetchRelease";
+import {
+  checkPropagationWhitelist,
+  propagateRelease,
+} from "utils/propagateRelease";
 import { resolveDnpName } from "utils/resolveDnpName";
 import { signRelease } from "utils/signRelease";
 import Button from "components/Button";
@@ -28,6 +32,7 @@ interface SignAndPublishProps {
   >;
   ipfsApiUrls: string;
   ipfsGatewayUrl: string;
+  propagationUrl: string;
 }
 
 export default function SignAndPublish({
@@ -41,6 +46,7 @@ export default function SignAndPublish({
   setPublishReqStatus,
   ipfsApiUrls,
   ipfsGatewayUrl,
+  propagationUrl,
 }: SignAndPublishProps) {
   const { address: account, getProvider } = useWallet();
   const provider = getProvider();
@@ -53,6 +59,14 @@ export default function SignAndPublish({
   const [isAllowedAddress, setIsAllowedAddress] = useState<boolean | null>(
     null,
   );
+
+  const [isPropagationWhitelisted, setIsPropagationWhitelisted] = useState<
+    boolean | null
+  >(null);
+  const [propagationStatus, setPropagationStatus] = useState<
+    "idle" | "signing" | "dispatched" | "error"
+  >("idle");
+  const [propagationError, setPropagationError] = useState<string | null>(null);
 
   //Checks if the wallet address is whitelisted to publish
   useEffect(() => {
@@ -74,6 +88,37 @@ export default function SignAndPublish({
       })();
     }
   }, [account, dnpName, provider]);
+
+  // Check propagation whitelist after release is signed
+  useEffect(() => {
+    if (signedReleaseHash && propagationUrl && account) {
+      checkPropagationWhitelist(propagationUrl, account).then(
+        setIsPropagationWhitelisted,
+      );
+    }
+  }, [signedReleaseHash, propagationUrl, account]);
+
+  async function doPropagate() {
+    try {
+      if (!signReq.result) return;
+      setPropagationStatus("signing");
+      setPropagationError(null);
+      const signer = await provider.getSigner();
+      await propagateRelease(
+        propagationUrl,
+        signReq.result,
+        signer,
+        account!,
+      );
+      setPropagationStatus("dispatched");
+    } catch (e) {
+      console.warn("Propagation failed", e);
+      setPropagationStatus("error");
+      setPropagationError(
+        e instanceof Error ? e.message : "Propagation failed",
+      );
+    }
+  }
 
   const details: ReleaseDetails[] = [
     {
@@ -206,6 +251,33 @@ export default function SignAndPublish({
           <p className="text-center text-success-green">
             The release is ready to be published
           </p>
+
+          {isPropagationWhitelisted && propagationStatus === "idle" && (
+            <div className="rounded-xl border border-text-purple/20 p-3">
+              <p className="text-sm font-medium text-text-purple">
+                Propagate to DAppNode network
+              </p>
+              <p className="mb-2 text-xs text-gray-500">
+                Pin and advertise this release across DAppNode infrastructure.
+                This requires one additional signature.
+              </p>
+              <Button onClick={doPropagate}>Propagate</Button>
+            </div>
+          )}
+          {propagationStatus === "signing" && (
+            <LoadingView steps={["Signing propagation request"]} />
+          )}
+          {propagationStatus === "dispatched" && (
+            <p className="text-center text-sm text-success-green">
+              Propagation dispatched successfully
+            </p>
+          )}
+          {propagationStatus === "error" && (
+            <p className="text-center text-sm text-orange-500">
+              Propagation failed: {propagationError}. You can still publish.
+            </p>
+          )}
+
           {publishReqStatus.error && (
             <div className="text-sm text-error-red">
               Error while trying to publish the release. For more information

--- a/src/pages/publishing/steps/SignAndPublishStep.tsx
+++ b/src/pages/publishing/steps/SignAndPublishStep.tsx
@@ -13,6 +13,7 @@ import { fetchReleaseSignature } from "utils/fetchRelease";
 import {
   checkPropagationWhitelist,
   propagateRelease,
+  propagateReleaseWithApiKey,
 } from "utils/propagateRelease";
 import { resolveDnpName } from "utils/resolveDnpName";
 import { signRelease } from "utils/signRelease";
@@ -33,6 +34,7 @@ interface SignAndPublishProps {
   ipfsApiUrls: string;
   ipfsGatewayUrl: string;
   propagationUrl: string;
+  propagationApiKey: string;
 }
 
 export default function SignAndPublish({
@@ -47,6 +49,7 @@ export default function SignAndPublish({
   ipfsApiUrls,
   ipfsGatewayUrl,
   propagationUrl,
+  propagationApiKey,
 }: SignAndPublishProps) {
   const { address: account, getProvider } = useWallet();
   const provider = getProvider();
@@ -92,11 +95,38 @@ export default function SignAndPublish({
   // Check propagation whitelist after release is signed
   useEffect(() => {
     if (signedReleaseHash && propagationUrl && account) {
-      checkPropagationWhitelist(propagationUrl, account).then(
-        setIsPropagationWhitelisted,
-      );
+      // If API key is set, skip whitelist check — just mark as whitelisted
+      if (propagationApiKey) {
+        setIsPropagationWhitelisted(true);
+      } else {
+        checkPropagationWhitelist(propagationUrl, account).then(
+          setIsPropagationWhitelisted,
+        );
+      }
     }
-  }, [signedReleaseHash, propagationUrl, account]);
+  }, [signedReleaseHash, propagationUrl, account, propagationApiKey]);
+
+  // Auto-propagate when API key is present (no signature needed)
+  useEffect(() => {
+    if (
+      isPropagationWhitelisted &&
+      propagationApiKey &&
+      signReq.result &&
+      propagationUrl &&
+      propagationStatus === "idle"
+    ) {
+      setPropagationStatus("signing");
+      propagateReleaseWithApiKey(propagationUrl, signReq.result, propagationApiKey)
+        .then(() => setPropagationStatus("dispatched"))
+        .catch((e) => {
+          console.warn("Propagation with API key failed", e);
+          setPropagationStatus("error");
+          setPropagationError(
+            e instanceof Error ? e.message : "Propagation failed",
+          );
+        });
+    }
+  }, [isPropagationWhitelisted, propagationApiKey, signReq.result, propagationUrl, propagationStatus]);
 
   async function doPropagate() {
     try {
@@ -252,7 +282,7 @@ export default function SignAndPublish({
             The release is ready to be published
           </p>
 
-          {isPropagationWhitelisted && propagationStatus === "idle" && (
+          {isPropagationWhitelisted && !propagationApiKey && propagationStatus === "idle" && (
             <div className="rounded-xl border border-text-purple/20 p-3">
               <p className="text-sm font-medium text-text-purple">
                 Propagate to DAppNode network
@@ -265,7 +295,7 @@ export default function SignAndPublish({
             </div>
           )}
           {propagationStatus === "signing" && (
-            <LoadingView steps={["Signing propagation request"]} />
+            <LoadingView steps={["Propagating release"]} />
           )}
           {propagationStatus === "dispatched" && (
             <p className="text-center text-sm text-success-green">

--- a/src/params.ts
+++ b/src/params.ts
@@ -11,3 +11,7 @@ export const SDK_INSTALL_URL = "https://github.com/dappnode/DAppNodeSDK";
 
 export const signatureFileName = "signature.json";
 export const manifestFileName = "dappnode_package.json";
+
+// Propagation
+export const DEFAULT_PROPAGATION_URL =
+  process.env.REACT_APP_PROPAGATION_URL || "https://bot.dappnode.net";

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -49,3 +49,13 @@ export function readPropagationUrl(): string {
 export function writePropagationUrl(propagationUrl: string): void {
   localStorage.setItem(propagationUrlKey, propagationUrl);
 }
+
+const propagationApiKeyKey = "propagation-api-key";
+
+export function readPropagationApiKey(): string {
+  return localStorage.getItem(propagationApiKeyKey) ?? "";
+}
+
+export function writePropagationApiKey(apiKey: string): void {
+  localStorage.setItem(propagationApiKeyKey, apiKey);
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,8 @@
-import { DEFAULT_IPFS_GATEWAY, LEGACY_IPFS_GATEWAY } from "params";
+import {
+  DEFAULT_IPFS_GATEWAY,
+  DEFAULT_PROPAGATION_URL,
+  LEGACY_IPFS_GATEWAY,
+} from "params";
 
 const ipfsApiUrlsKey = "ipfs-api-urls";
 
@@ -34,4 +38,14 @@ export function parseIpfsUrls(ipfsApiUrls: string): string[] {
     .split("\n")
     .map((row) => row.trim())
     .filter((row) => row);
+}
+
+const propagationUrlKey = "propagation-url";
+
+export function readPropagationUrl(): string {
+  return localStorage.getItem(propagationUrlKey) ?? DEFAULT_PROPAGATION_URL;
+}
+
+export function writePropagationUrl(propagationUrl: string): void {
+  localStorage.setItem(propagationUrlKey, propagationUrl);
 }

--- a/src/utils/propagateRelease.ts
+++ b/src/utils/propagateRelease.ts
@@ -1,0 +1,53 @@
+import { ethers } from "ethers";
+
+const CID_PATTERN = /^(Qm[a-zA-Z0-9]{44,}|bafy[a-zA-Z0-9]{44,})$/;
+
+function isValidCid(cid: string): boolean {
+  return CID_PATTERN.test(cid);
+}
+
+export async function checkPropagationWhitelist(
+  propagationUrl: string,
+  address: string,
+): Promise<boolean> {
+  try {
+    const res = await fetch(
+      `${propagationUrl}/api/address/${ethers.getAddress(address)}`,
+    );
+    return res.status === 200;
+  } catch (e) {
+    console.warn("Propagation whitelist check failed", e);
+    return false;
+  }
+}
+
+export async function propagateRelease(
+  propagationUrl: string,
+  cid: string,
+  signer: ethers.Signer,
+  address: string,
+): Promise<void> {
+  if (!isValidCid(cid)) {
+    throw new Error(`Invalid CID format: ${cid}`);
+  }
+
+  const body = JSON.stringify({ cid });
+  const signature = await signer.signMessage(body);
+
+  const res = await fetch(`${propagationUrl}/api/propagate-content`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Address": ethers.getAddress(address),
+      "X-Signature": signature,
+    },
+    body,
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `Propagation request failed (${res.status}): ${text}`,
+    );
+  }
+}

--- a/src/utils/propagateRelease.ts
+++ b/src/utils/propagateRelease.ts
@@ -51,3 +51,31 @@ export async function propagateRelease(
     );
   }
 }
+
+export async function propagateReleaseWithApiKey(
+  propagationUrl: string,
+  cid: string,
+  apiKey: string,
+): Promise<void> {
+  if (!isValidCid(cid)) {
+    throw new Error(`Invalid CID format: ${cid}`);
+  }
+
+  const body = JSON.stringify({ cid });
+
+  const res = await fetch(`${propagationUrl}/api/propagate-content`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-API-Key": apiKey,
+    },
+    body,
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `Propagation request failed (${res.status}): ${text}`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

After `signRelease()` produces the signed release CID, optionally call the DAppNode propagation API to pin and advertise the CID across infrastructure.

## Changes

- **`src/params.ts`** — Add `DEFAULT_PROPAGATION_URL` constant (`https://bot.dappnode.net`, overridable via `REACT_APP_PROPAGATION_URL` env var)
- **`src/settings.ts`** — Add `readPropagationUrl()` / `writePropagationUrl()` localStorage helpers
- **`src/utils/propagateRelease.ts`** — New utility with:
  - `checkPropagationWhitelist(url, address)` — `GET /api/address/<addr>`, returns `true` on 200, `false` on 404/error
  - `propagateRelease(url, cid, signer, address)` — signs body with `signMessage`, POSTs to `/api/propagate-content` with `X-Address`/`X-Signature` headers
- **`src/pages/publishing/steps/IpfsSettingsStep.tsx`** — Add propagation API URL input field
- **`src/pages/publishing/Publishing.tsx`** — Wire `propagationUrl` state through wizard
- **`src/pages/publishing/steps/SignAndPublishStep.tsx`** — Main integration:
  - After signing, check whitelist via `GET /api/address/<address>`
  - If whitelisted: show "Propagate to DAppNode network" button
  - If not whitelisted or URL empty: skip silently (no popup)
  - Propagation is **non-blocking** — errors show an orange warning, never prevent publishing

## UX Flow

1. User signs the release (existing flow, unchanged)
2. After signing succeeds, whitelist check fires automatically
3. If address is authorized → "Propagate" button appears (one additional `signMessage` popup)
4. If not authorized → nothing shown, user proceeds to Publish as before
5. Propagation success/failure never blocks the Publish button

## API Contract

```
POST <PROPAGATION_URL>/api/propagate-content
Content-Type: application/json
X-Address: <checksummed_address>
X-Signature: <personal_sign(body)>
Body: {"cid": "QmXyz..."}
```