### PR TITLE
feat: move propagation API key to header popup and hide propagation URL

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,12 +1,34 @@
-import React from "react";
+import React, { useState, useRef, useEffect } from "react";
 import dappnodeLogo from "img/dappnode-logo-only.png";
 import { Link } from "react-router-dom";
 import { useWallet } from "wallet/useWallet";
 import { useAppKit } from "@reown/appkit/react";
+import { readPropagationApiKey, writePropagationApiKey } from "settings";
 
 export default function Header() {
   const { open } = useAppKit();
   const { isConnected } = useWallet();
+
+  const [showApiKeyPopup, setShowApiKeyPopup] = useState(false);
+  const [apiKey, setApiKey] = useState(readPropagationApiKey());
+  const popupRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (popupRef.current && !popupRef.current.contains(e.target as Node)) {
+        setShowApiKeyPopup(false);
+      }
+    }
+    if (showApiKeyPopup) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [showApiKeyPopup]);
+
+  function saveApiKey() {
+    writePropagationApiKey(apiKey);
+    setShowApiKeyPopup(false);
+  }
 
   return (
     <div className="flex h-[10%] w-full items-center justify-between bg-white px-10">
@@ -32,16 +54,67 @@ export default function Header() {
             Ownership
           </Link>
         </nav>
-        {isConnected ? (
-          <appkit-account-button />
-        ) : (
-          <button
-            className={`flex items-center justify-center rounded-2xl bg-default-purple px-2 pb-1.5 pt-2 text-sm text-text-purple transition-all duration-300 ease-in-out hover:bg-focused-purple hover:tracking-wide hover:text-white disabled:bg-background-color disabled:tracking-normal disabled:text-gray-400 `}
-            onClick={() => open({ view: "Connect" })}
-          >
-            Connect Wallet
-          </button>
-        )}
+        <div className="flex items-center gap-3">
+          <div className="relative" ref={popupRef}>
+            <button
+              className="flex items-center justify-center rounded-2xl border border-text-purple/30 px-3 py-1.5 text-sm text-text-purple transition-all hover:bg-purple-50"
+              onClick={() => setShowApiKeyPopup(!showApiKeyPopup)}
+              title="Propagation API Key"
+            >
+              🔑 API Key
+              {apiKey && (
+                <span className="ml-1.5 h-2 w-2 rounded-full bg-success-green" />
+              )}
+            </button>
+            {showApiKeyPopup && (
+              <div className="absolute right-0 top-full z-50 mt-2 w-80 rounded-xl border border-gray-200 bg-white p-4 shadow-lg">
+                <p className="mb-1 text-sm font-medium text-text-purple">
+                  Propagation API Key
+                </p>
+                <p className="mb-3 text-xs text-gray-500">
+                  Set your API key for automatic propagation. Persists across
+                  sessions.
+                </p>
+                <input
+                  className="w-full rounded-xl bg-background-color p-2 text-sm focus:outline-focused-purple"
+                  type="password"
+                  placeholder="Enter API key"
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                  onKeyDown={(e) => e.key === "Enter" && saveApiKey()}
+                />
+                <div className="mt-3 flex justify-end gap-2">
+                  <button
+                    className="rounded-lg px-3 py-1 text-xs text-gray-500 hover:bg-gray-100"
+                    onClick={() => {
+                      setApiKey("");
+                      writePropagationApiKey("");
+                      setShowApiKeyPopup(false);
+                    }}
+                  >
+                    Clear
+                  </button>
+                  <button
+                    className="rounded-lg bg-default-purple px-3 py-1 text-xs text-text-purple hover:bg-focused-purple hover:text-white"
+                    onClick={saveApiKey}
+                  >
+                    Save
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+          {isConnected ? (
+            <appkit-account-button />
+          ) : (
+            <button
+              className={`flex items-center justify-center rounded-2xl bg-default-purple px-2 pb-1.5 pt-2 text-sm text-text-purple transition-all duration-300 ease-in-out hover:bg-focused-purple hover:tracking-wide hover:text-white disabled:bg-background-color disabled:tracking-normal disabled:text-gray-400 `}
+              onClick={() => open({ view: "Connect" })}
+            >
+              Connect Wallet
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/publishing/Publishing.tsx
+++ b/src/pages/publishing/Publishing.tsx
@@ -1,6 +1,6 @@
 import { DEFAULT_IPFS_API, DEFAULT_IPFS_GATEWAY } from "params";
 import React, { useEffect, useState } from "react";
-import { readIpfsApiUrls, readIpfsGatewayUrl, readPropagationApiKey, readPropagationUrl } from "settings";
+import { readIpfsApiUrls, readIpfsGatewayUrl } from "settings";
 import { RepoAddresses, RequestStatus } from "types";
 import { parseUrlQuery } from "utils/urlQuery";
 import IntroductionStep from "pages/publishing/steps/IntroductionStep";
@@ -29,10 +29,6 @@ export function Publishing() {
   );
   const [ipfsGatewayUrl, setIpfsGatewayUrl] = useState(
     readIpfsGatewayUrl() === "" ? DEFAULT_IPFS_GATEWAY : readIpfsGatewayUrl(),
-  );
-  const [propagationUrl, setPropagationUrl] = useState(readPropagationUrl());
-  const [propagationApiKey, setPropagationApiKey] = useState(
-    readPropagationApiKey(),
   );
 
   // Set state based on URL parameters
@@ -69,10 +65,6 @@ export function Publishing() {
             setIpfsApiUrls={setIpfsApiUrls}
             ipfsGatewayUrl={ipfsGatewayUrl}
             setIpfsGatewayUrl={setIpfsGatewayUrl}
-            propagationUrl={propagationUrl}
-            setPropagationUrl={setPropagationUrl}
-            propagationApiKey={propagationApiKey}
-            setPropagationApiKey={setPropagationApiKey}
           />
         );
       case 2:
@@ -105,8 +97,6 @@ export function Publishing() {
             setPublishReqStatus={setPublishReqStatus}
             ipfsApiUrls={ipfsApiUrls}
             ipfsGatewayUrl={ipfsGatewayUrl}
-            propagationUrl={propagationUrl}
-            propagationApiKey={propagationApiKey}
           />
         );
       case 4:

--- a/src/pages/publishing/steps/IpfsSettingsStep.tsx
+++ b/src/pages/publishing/steps/IpfsSettingsStep.tsx
@@ -2,8 +2,6 @@ import React, { useEffect } from "react";
 import {
   writeIpfsApiUrls,
   writeIpfsGatewayUrl,
-  writePropagationApiKey,
-  writePropagationUrl,
 } from "settings";
 import BaseCard from "components/BaseCard";
 import Button from "components/Button";
@@ -15,10 +13,6 @@ interface IpfsSettingsStepProps {
   setIpfsApiUrls: React.Dispatch<React.SetStateAction<string>>;
   ipfsGatewayUrl: string;
   setIpfsGatewayUrl: React.Dispatch<React.SetStateAction<string>>;
-  propagationUrl: string;
-  setPropagationUrl: React.Dispatch<React.SetStateAction<string>>;
-  propagationApiKey: string;
-  setPropagationApiKey: React.Dispatch<React.SetStateAction<string>>;
 }
 
 export default function IpfsSettingsStep({
@@ -27,15 +21,9 @@ export default function IpfsSettingsStep({
   setIpfsApiUrls,
   ipfsGatewayUrl,
   setIpfsGatewayUrl,
-  propagationUrl,
-  setPropagationUrl,
-  propagationApiKey,
-  setPropagationApiKey,
 }: IpfsSettingsStepProps) {
   useEffect(() => writeIpfsApiUrls(ipfsApiUrls), [ipfsApiUrls]);
   useEffect(() => writeIpfsGatewayUrl(ipfsGatewayUrl), [ipfsGatewayUrl]);
-  useEffect(() => writePropagationUrl(propagationUrl), [propagationUrl]);
-  useEffect(() => writePropagationApiKey(propagationApiKey), [propagationApiKey]);
   return (
     <BaseCard hasBack={() => setStepper((prevState) => prevState - 1)}>
       <Title title={"2. Edit IPFS settings"} />
@@ -75,32 +63,7 @@ export default function IpfsSettingsStep({
           onChange={(e) => setIpfsGatewayUrl(e.target.value)}
         />
       </div>
-      <div className="flex flex-col gap-1">
-        <div className="text-text-purple">Propagation API URL</div>
-        <p className="text-sm">
-          URL of the DAppNode propagation service. Leave empty to disable.
-        </p>
-        <input
-          className={
-            " rounded-2xl bg-background-color p-3  focus:outline-focused-purple "
-          }
-          placeholder="https://propagation-api.dappnode.io"
-          value={propagationUrl}
-          onChange={(e) => setPropagationUrl(e.target.value)}
-        />
-      </div>
-      <div className="flex flex-col gap-1">
-        <div className="text-text-purple text-xs">API Key</div>
-        <input
-          className={
-            " rounded-2xl bg-background-color p-3 text-xs focus:outline-focused-purple "
-          }
-          type="password"
-          placeholder="Optional — skips signature prompt"
-          value={propagationApiKey}
-          onChange={(e) => setPropagationApiKey(e.target.value)}
-        />
-      </div>
+
       <Button onClick={() => setStepper((prevState) => prevState + 1)}>
         Next
       </Button>

--- a/src/pages/publishing/steps/SignAndPublishStep.tsx
+++ b/src/pages/publishing/steps/SignAndPublishStep.tsx
@@ -6,7 +6,7 @@ import Title from "components/Title";
 
 import { ErrorView } from "components/ErrorView";
 import { LoadingView } from "components/LoadingView";
-import { parseIpfsUrls } from "settings";
+import { parseIpfsUrls, readPropagationApiKey, readPropagationUrl } from "settings";
 import { apmRepoIsAllowed } from "utils/apmRepoIsAllowed";
 import { executePublishTx } from "utils/executePublishTx";
 import { fetchReleaseSignature } from "utils/fetchRelease";
@@ -33,8 +33,6 @@ interface SignAndPublishProps {
   >;
   ipfsApiUrls: string;
   ipfsGatewayUrl: string;
-  propagationUrl: string;
-  propagationApiKey: string;
 }
 
 export default function SignAndPublish({
@@ -48,11 +46,12 @@ export default function SignAndPublish({
   setPublishReqStatus,
   ipfsApiUrls,
   ipfsGatewayUrl,
-  propagationUrl,
-  propagationApiKey,
 }: SignAndPublishProps) {
   const { address: account, getProvider } = useWallet();
   const provider = getProvider();
+
+  const propagationUrl = readPropagationUrl();
+  const propagationApiKey = readPropagationApiKey();
 
   const [signedReleaseHash, setSignedReleaseHash] = useState<string>("");
 


### PR DESCRIPTION
## Changes

- **Hide propagation API URL from UI**: Removed the propagation URL input field from the IPFS settings page. The URL is still used internally via localStorage/default value.
- **Move API key to header popup**: Added a persistent popup in the header bar (🔑 API Key button) where users can set/clear their propagation API key. The key persists across sessions via localStorage. A green dot indicator shows when a key is configured.
- **Simplify prop threading**: SignAndPublishStep now reads propagationUrl and propagationApiKey directly from localStorage settings instead of receiving them as props from the parent.